### PR TITLE
Update cli lib reference

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/litl/rdstail/src"
 )
 


### PR DESCRIPTION
Should use the updated reference to golang cli lib, see notice at https://github.com/urfave/cli/blob/master/README.md
